### PR TITLE
fix curl error when GET from expired/unknown SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,windows,osx
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,windows,osx
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,windows,osx

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,12 @@
+# Contributors
+
+This list is sorted alphabetically. 
+
+## Core Team
+
+* **[Andrew Lisowski](https://github.com/hipstersmoothie)**
+
+## Others
+
+* **[Chris Ochieng](https://github.com/jangita)** 
+

--- a/wallpaperChanger.sh
+++ b/wallpaperChanger.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-curl -Lo ~/Documents/wallPaperchanger/image.png "https://source.unsplash.com/random/2560x1600/"
+curl -k -Lo ~/Documents/wallPaperchanger/image.png "https://source.unsplash.com/random/2560x1600/"
 # Mavericks
 sqlite3 ~/Library/Application\ Support/Dock/desktoppicture.db "update data set value = '~/Documents/wallPaperchanger/image.png'" && killall Dock
 # Below Mavericks


### PR DESCRIPTION
After installed it i noticed that it was failing at the curl stage. Curl refuses to download from a URL of the SSL is unknown or has expired (or free for some reason) so added the -k option for curl to ignore that. Also added contributors.md and standard gitignore for vscode, windows and osx.